### PR TITLE
Prepare for message function

### DIFF
--- a/app/assets/stylesheets/chat_groups.scss
+++ b/app/assets/stylesheets/chat_groups.scss
@@ -32,17 +32,22 @@
     }
     .sidebar__column {
       height: calc(100% - 100px);
-      padding: 0 20px;
-      .groups .group {
-        padding: 20px 0;
-        .group__title {
-          color: #ffffff;
-          font-size: 15px;
-        }
-        .group__content {
-          color: #ffffff;
-          font-size: 11px;
-          margin-top: 5px;
+      ul.groups a {
+        text-decoration: none;
+        li.group {
+          &:hover {
+            background-color: #3d526d;
+          }
+          padding: 20px;
+          .group__title {
+            color: #ffffff;
+            font-size: 15px;
+          }
+          .group__content {
+            color: #ffffff;
+            font-size: 11px;
+            margin-top: 5px;
+          }
         }
       }
     }

--- a/app/controllers/chat_groups_controller.rb
+++ b/app/controllers/chat_groups_controller.rb
@@ -2,6 +2,7 @@ class ChatGroupsController < ApplicationController
   before_action :set_group, only: [:edit, :update]
 
   def index
+    @groups = current_user.groups
   end
 
   def new

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,4 @@
+class MessagesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,5 @@
 class MessagesController < ApplicationController
   def index
+    @groups = current_user.groups
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,7 @@
 class MessagesController < ApplicationController
   def index
+    @group = Group.find(params[:chat_group_id])
     @groups = current_user.groups
+    @members = @group.group_members
   end
 end

--- a/app/views/chat_groups/index.html.haml
+++ b/app/views/chat_groups/index.html.haml
@@ -1,7 +1,7 @@
 .contents
   .sidebar
     .sidebar__top
-      %span.sidebar__top-left junichi sato
+      %span.sidebar__top-left= current_user.name
       .sidebar__top-right
         = link_to fa_icon("pencil-square-o"), new_chat_group_path
         = link_to fa_icon("cog"), edit_user_registration_path

--- a/app/views/chat_groups/index.html.haml
+++ b/app/views/chat_groups/index.html.haml
@@ -7,15 +7,10 @@
         = link_to fa_icon("cog"), edit_user_registration_path
     .sidebar__column
       %ul.groups
-        %li.group
-          .group__title Group1
-          .group__content message
-        %li.group
-          .group__title Group2
-          .group__content message
-        %li.group
-          .group__title Group3
-          .group__content message
+        - @groups.each do |group|
+          %li.group
+            .group__title= group.name
+            .group__content message
   .message-board
     .message-board__header
       .message-board__header-left

--- a/app/views/chat_groups/index.html.haml
+++ b/app/views/chat_groups/index.html.haml
@@ -3,27 +3,8 @@
   .message-board
     .message-board__header
       .message-board__header-left
-        .header__group-name sample group
-        .header__group-members Members: junichi sato
       .message-board__header-right
-        = link_to "Edit", '#'
     .message-board__content
-      %ul.messages
-        %li.message
-          .message__user
-            %span.message__user-name junichi sato
-            %span.message__posted-time 2016/11/9 19:42:15
-          .message__content sample
-        %li.message
-          .message__user
-            %span.message__user-name junichi sato
-            %span.message__posted-time 2016/11/9 19:45:34
-          .message__content great
-        %li.message
-          .message__user
-            %span.message__user-name junichi sato
-            %span.message__posted-time 2016/11/9 19:50:22
-          .message__content wow
     .message-board__footer
       %form
         .footer__message

--- a/app/views/chat_groups/index.html.haml
+++ b/app/views/chat_groups/index.html.haml
@@ -1,17 +1,5 @@
 .contents
-  .sidebar
-    .sidebar__top
-      %span.sidebar__top-left= current_user.name
-      .sidebar__top-right
-        = link_to fa_icon("pencil-square-o"), new_chat_group_path
-        = link_to fa_icon("cog"), edit_user_registration_path
-    .sidebar__column
-      %ul.groups
-        - @groups.each do |group|
-          =link_to(chat_group_messages_path(group)) do
-            %li.group
-              .group__title= group.name
-              .group__content message
+  = render partial: "layouts/sidebar"
   .message-board
     .message-board__header
       .message-board__header-left

--- a/app/views/chat_groups/index.html.haml
+++ b/app/views/chat_groups/index.html.haml
@@ -8,9 +8,10 @@
     .sidebar__column
       %ul.groups
         - @groups.each do |group|
-          %li.group
-            .group__title= group.name
-            .group__content message
+          =link_to(chat_group_messages_path(group)) do
+            %li.group
+              .group__title= group.name
+              .group__content message
   .message-board
     .message-board__header
       .message-board__header-left

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -1,0 +1,13 @@
+.sidebar
+  .sidebar__top
+    %span.sidebar__top-left= current_user.name
+    .sidebar__top-right
+      = link_to fa_icon("pencil-square-o"), new_chat_group_path
+      = link_to fa_icon("cog"), edit_user_registration_path
+  .sidebar__column
+    %ul.groups
+      - @groups.each do |group|
+        =link_to(chat_group_messages_path(group)) do
+          %li.group
+            .group__title= group.name
+            .group__content message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,8 +3,10 @@
   .message-board
     .message-board__header
       .message-board__header-left
-        .header__group-name sample group
-        .header__group-members Members: junichi sato
+        .header__group-name= @group.name
+        %span.header__group-members Members:
+        - @members.each do |member|
+          %span.header__group-members= member.user.name
       .message-board__header-right
         = link_to "Edit", '#'
     .message-board__content

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,21 +1,5 @@
 .contents
-  .sidebar
-    .sidebar__top
-      %span.sidebar__top-left junichi sato
-      .sidebar__top-right
-        = link_to fa_icon("pencil-square-o"), new_chat_group_path
-        = link_to fa_icon("cog"), edit_user_registration_path
-    .sidebar__column
-      %ul.groups
-        %li.group
-          .group__title Group1
-          .group__content message
-        %li.group
-          .group__title Group2
-          .group__content message
-        %li.group
-          .group__title Group3
-          .group__content message
+  = render partial: "layouts/sidebar"
   .message-board
     .message-board__header
       .message-board__header-left

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -8,7 +8,7 @@
         - @members.each do |member|
           %span.header__group-members= member.user.name
       .message-board__header-right
-        = link_to "Edit", '#'
+        = link_to "Edit", edit_chat_group_path(@group)
     .message-board__content
       %ul.messages
         %li.message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,0 +1,51 @@
+.contents
+  .sidebar
+    .sidebar__top
+      %span.sidebar__top-left junichi sato
+      .sidebar__top-right
+        = link_to fa_icon("pencil-square-o"), new_chat_group_path
+        = link_to fa_icon("cog"), edit_user_registration_path
+    .sidebar__column
+      %ul.groups
+        %li.group
+          .group__title Group1
+          .group__content message
+        %li.group
+          .group__title Group2
+          .group__content message
+        %li.group
+          .group__title Group3
+          .group__content message
+  .message-board
+    .message-board__header
+      .message-board__header-left
+        .header__group-name sample group
+        .header__group-members Members: junichi sato
+      .message-board__header-right
+        = link_to "Edit", '#'
+    .message-board__content
+      %ul.messages
+        %li.message
+          .message__user
+            %span.message__user-name junichi sato
+            %span.message__posted-time 2016/11/9 19:42:15
+          .message__content sample
+        %li.message
+          .message__user
+            %span.message__user-name junichi sato
+            %span.message__posted-time 2016/11/9 19:45:34
+          .message__content great
+        %li.message
+          .message__user
+            %span.message__user-name junichi sato
+            %span.message__posted-time 2016/11/9 19:50:22
+          .message__content wow
+    .message-board__footer
+      %form
+        .footer__message
+          %textarea#form{placeholder: 'type a message'}
+          .image-upload
+            %label{for: "file-input"}
+              = fa_icon "picture-o"
+            %input{id: "file-input", type: "file"}
+        %input#send-button{type: :submit, value: 'Send'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :chat_groups, except: [:show, :destroy]
+  resources :chat_groups, except: [:show, :destroy] do
     resources :messages, only: :index
+  end
   root to: 'chat_groups#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   resources :chat_groups, except: [:show, :destroy]
+    resources :messages, only: :index
   root to: 'chat_groups#index'
 end


### PR DESCRIPTION
## WHAT
トップページとメッセージ画面を分け、それぞれ正しい情報を表示できるようにする

## WHY
トップページではチャットを表示せず、グループ選択後に初めてチャット画面に遷移するようにするため
またそうすることによって、以降のメッセージ機能追加時に作業の効率化を図るため