### PR TITLE
Introduce Amazon s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 
 # Ignore vendor/bundle
 /vendor/bundle
+
+# Ignore dotenv environemt configuration
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ gem 'devise'                              # Enable user functions
 gem 'carrierwave'                         # Simple and flexible file uploader
 gem 'mini_magick'                         # A ruby wrapper for ImageMagick or GraphicsMagick command line.
 
+# AWS S3 related libraries
+gem 'fog-aws'                             # Module for the 'fog' gem to support Amazon Web Services http://aws.amazon.com/
+gem 'dotenv-rails'                        # Loads environment variables from `.env`.
+
 group :development, :test do
   gem 'byebug', platform: :mri            # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-rails'                         # Call 'binding.pry' anywhere in the code to stop execution and start console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,9 +58,14 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erb2haml (0.1.5)
       html2haml
     erubis (2.7.0)
+    excon (0.54.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -70,8 +75,24 @@ GEM
     faker (1.6.3)
       i18n (~> 0.5)
     ffi (1.9.14)
+    fog-aws (1.1.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.43.0)
+      builder
+      excon (~> 0.49)
+      formatador (~> 0.2)
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     font-awesome-rails (4.7.0.0)
       railties (>= 3.2, < 5.1)
+    formatador (0.2.5)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     haml (4.0.7)
@@ -88,6 +109,7 @@ GEM
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
     i18n (0.7.0)
+    ipaddress (0.8.3)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -224,9 +246,11 @@ DEPENDENCIES
   byebug
   carrierwave
   devise
+  dotenv-rails
   erb2haml
   factory_girl_rails
   faker
+  fog-aws
   font-awesome-rails
   haml-rails
   jbuilder (~> 2.5)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -7,7 +7,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
+  # storage :file
   # storage :fog
 
   # Override the directory where uploaded files will be stored.

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,7 @@
+CarrierWave.configure do |config|
+  if Rails.env.test?
+    config.storage = :file
+  elsif Rails.env.development? || Rails.env.production?
+    config.storage = :fog
+  end
+end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,5 +3,13 @@ CarrierWave.configure do |config|
     config.storage = :file
   elsif Rails.env.development? || Rails.env.production?
     config.storage = :fog
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      region: "ap-northeast-1"
+    }
+    config.fog_directory = ENV["S3_BUCKET"]
+    config.asset_host = ENV["ASSET_HOST"]
   end
 end


### PR DESCRIPTION
## WHAT
投稿された画像の保存先としてs3を利用する

## WHY
外部のストレージを使うことによって、画像アップロードによって容量が逼迫することを避けるため