### PR TITLE
Replace redirect_to with render

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -50,6 +50,7 @@ $(function() {
     })
     .fail(function() {
       alert('error');
+      $('input[type="submit"]').prop('disabled', false);
     })
   });
 });

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -35,6 +35,10 @@ class GroupsController < ApplicationController
     end
   end
 
+  def show
+    redirect_to edit_group_path
+  end
+
   private
   def set_group
     @group = Group.find(params[:id])

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,7 +22,6 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @members = @group.users
   end
 
   def update
@@ -31,13 +30,15 @@ class GroupsController < ApplicationController
       @group.update(group_params)
       redirect_to :root, notice: 'グループが更新されました' and return
     else
-      redirect_to edit_group_path, alert: 'グループが更新されませんでした' and return
+      flash[:alert] = 'グループが更新されませんでした'
+      render action: :edit
     end
   end
 
   private
   def set_group
     @group = Group.find(params[:id])
+    @members = @group.users
   end
 
   def set_members

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,8 +7,7 @@ class GroupsController < ApplicationController
     @groups = current_user.groups
   end
 
-  def new
-  end
+  def new; end
 
   def create
     @group = Group.new(group_params)
@@ -21,8 +20,7 @@ class GroupsController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     group = Group.new(group_params)
@@ -40,6 +38,7 @@ class GroupsController < ApplicationController
   end
 
   private
+
   def set_group
     @group = Group.find(params[:id])
     @members = @group.users

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,15 +1,13 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:edit, :update]
   before_action :pass_users_to_json, only: [:new, :edit]
+  before_action :set_members, only: [:new, :create]
 
   def index
     @groups = current_user.groups
   end
 
   def new
-    @group = Group.new
-    @group.users << current_user
-    @members = @group.users
   end
 
   def create
@@ -18,7 +16,8 @@ class GroupsController < ApplicationController
       @group.save
       redirect_to :root, notice: 'グループが作成されました' and return
     else
-      redirect_to new_group_path, alert: 'グループが作成されませんでした' and return
+      flash[:alert] = 'グループが作成されませんでした'
+      render action: :new
     end
   end
 
@@ -39,6 +38,12 @@ class GroupsController < ApplicationController
   private
   def set_group
     @group = Group.find(params[:id])
+  end
+
+  def set_members
+    @group = Group.new
+    @group.users << current_user
+    @members = @group.users
   end
 
   def pass_users_to_json

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -15,7 +15,7 @@ class GroupsController < ApplicationController
       @group.save
       redirect_to :root, notice: 'グループが作成されました' and return
     else
-      flash[:alert] = 'グループが作成されませんでした'
+      flash.now[:alert] = 'グループが作成されませんでした'
       render action: :new
     end
   end
@@ -28,7 +28,7 @@ class GroupsController < ApplicationController
       @group.update(group_params)
       redirect_to :root, notice: 'グループが更新されました' and return
     else
-      flash[:alert] = 'グループが更新されませんでした'
+      flash.now[:alert] = 'グループが更新されませんでした'
       render action: :edit
     end
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -17,6 +17,7 @@ class MessagesController < ApplicationController
   end
 
   private
+
   def set_variables
     @group = Group.find(params[:group_id])
     @groups = current_user.groups

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,7 +12,7 @@ class MessagesController < ApplicationController
         format.json { render json: message }
       end
     else
-      flash[:alert] = 'メッセージが投稿されませんでした'
+      flash.now[:alert] = 'メッセージが投稿されませんでした'
       render action: :index
     end
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,11 +1,7 @@
 class MessagesController < ApplicationController
-  before_action :set_group
+  before_action :set_variables
 
   def index
-    @groups = current_user.groups
-    @members = @group.group_members
-    @message = Message.new
-    @messages = Message.includes(:user).where(group_id: @group.id)
   end
 
   def create
@@ -16,13 +12,18 @@ class MessagesController < ApplicationController
         format.json { render json: message }
       end
     else
-      redirect_to group_messages_path, alert: 'メッセージが投稿されませんでした' and return
+      flash[:alert] = 'メッセージが投稿されませんでした'
+      render action: :index
     end
   end
 
   private
-  def set_group
+  def set_variables
     @group = Group.find(params[:group_id])
+    @groups = current_user.groups
+    @members = @group.group_members
+    @message = Message.new
+    @messages = Message.includes(:user).where(group_id: @group.id)
   end
 
   def create_params

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,8 +1,7 @@
 class MessagesController < ApplicationController
   before_action :set_variables
 
-  def index
-  end
+  def index; end
 
   def create
     message = Message.new(create_params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :groups, except: [:show, :destroy] do
+  resources :groups, except: [:destroy] do
     resources :messages, only: [:index, :create]
   end
   root to: 'groups#index'


### PR DESCRIPTION
## WHAT
- 処理失敗時のredirect_toの処理をrenderに置き換える
- 置き換え時に生じるNoMethodErrorを解決する

## WHY
- renderはredirect_toと異なり、入力情報を持ち越すことができるため
- redirect_toの度にリクエストが発行され、処理が行われるのは効率的でないから
- renderを行うアクション内にrender先のアクションで使う変数を定義する必要がある