### PR TITLE
Asynchronize uploading images

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -72,7 +72,7 @@ $(function() {
     })
     .done(function(data) {
       $('.messages').append(buildHTML(data));
-      $('#message_body').val('');
+      resetInput($('#message_body'));
       window.scrollTo(0, document.body.scrollHeight);
       enableSubmitButton();
     })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -89,7 +89,7 @@ $(function() {
         imageChecker = $('input[type=file]')[0].files.length; // 変数を初期化する
       })
       .fail(function() {
-        alert('error');
+        alert('error communicating');
         enableSubmitButton();
       })
     };

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,4 +1,5 @@
 $(function() {
+  // 変数の定義
   var messageForm = $('#new_message');
   var fileInput = $('#file-input');
   var textField = $('#message_body');
@@ -27,6 +28,7 @@ $(function() {
                     message.body +
                   '</div>' +
                 '</li>');
+    // 画像が送信された時にのみ画像表示テンプレートを当てる
     if (imageChecker !== 0) {
       html.append(
         '<div class="message__image">' +

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -31,14 +31,14 @@ $(function() {
   }
 
   // formDataの形式を整える
-  function buildFormData(form) {
-    var formData = new FormData(form.get(0));
+  function buildFormData(f) {
+    var fd = new FormData(f.get(0));
     var message = $('.footer__message').val();
     var file = $('input[type=file]')[0].files[0];
-    formData.append("body", message);
-    formData.append("image", file);
+    fd.append("body", message);
+    fd.append("image", file);
 
-    return formData;
+    return fd;
   }
 
   // submit時にjsonで非同期通信を行う

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -15,7 +15,7 @@ $(function() {
   // 部分テンプレート_messageの構造に沿う
   function buildHTML(message) {
     var user = $('.sidebar__top-left').html();
-    var html = $('<li class="message">').append(
+    var html = $('<li class="message">' +
                   '<div class="message__user">' +
                     '<span class="message__user-name">' +
                       user +

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,4 +1,6 @@
 $(function() {
+  var messageForm = $('#new_message');
+
   // チャット画面において10秒おきに画面を更新する
   if ($('body').attr('controller') == 'messages') {
     setInterval(function() {
@@ -25,27 +27,32 @@ $(function() {
     return html;
   }
 
+  // formDataの形式を整える
+  function buildFormData(form) {
+    var formData = new FormData(form.get(0));
+    var message = $('.footer__message').val();
+    var file = $('input[type=file]')[0].files[0];
+    formData.append("body", message);
+    formData.append("image", file);
+
+    return formData;
+  }
+
   // submit時にjsonで非同期通信を行う
-  $('#message-form form').on('submit', function(e) {
+  messageForm.on('submit', function(e) {
     e.preventDefault();
-    var textField = $('.footer__message');
-    var message = textField.val();
-    var groupId = $('form.new_message input#message_group_id').attr('value');
+    var formData = buildFormData(messageForm);
     $.ajax({
       type: 'POST',
-      url: '/groups/' + groupId + '/messages.json',
-      data: {
-        message: {
-          body: message
-        }
-      },
-      datatype: 'json'
+      url: './messages.json',
+      data: formData,
+      processData: false,
+      contentType: false
     })
     .done(function(data) {
-      var html = buildHTML(data);
-      $('.messages').append(html);
+      $('.messages').append(buildHTML(data));
+      $('#message_body').val('');
       window.scrollTo(0, document.body.scrollHeight);
-      textField.val('');
       $('input[type="submit"]').prop('disabled', false);
     })
     .fail(function() {

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,6 +1,8 @@
 $(function() {
   var messageForm = $('#new_message');
   var fileInput = $('#file-input');
+  var textField = $('#message_body');
+  var imageChecker = $('input[type=file]')[0].files.length;
 
   // チャット画面において10秒おきに画面を更新する
   if ($('body').attr('controller') == 'messages') {
@@ -37,7 +39,7 @@ $(function() {
     var message = $('.footer__message').val();
     var file = $('input[type=file]')[0].files[0];
     fd.append("body", message);
-    fd.append("image", file);
+    if (imageChecker !== 0) { fd.append("image", file) };
 
     return fd;
   }
@@ -62,23 +64,28 @@ $(function() {
   // submit時にjsonで非同期通信を行う
   messageForm.on('submit', function(e) {
     e.preventDefault();
-    var formData = buildFormData(messageForm);
-    $.ajax({
-      type: 'POST',
-      url: './messages.json',
-      data: formData,
-      processData: false,
-      contentType: false
-    })
-    .done(function(data) {
-      $('.messages').append(buildHTML(data));
-      resetInput($('#message_body'));
-      window.scrollTo(0, document.body.scrollHeight);
-      enableSubmitButton();
-    })
-    .fail(function() {
-      alert('error');
-      enableSubmitButton();
-    })
+    // テキストと画像の両方が空の際は処理に進まないバリデーション
+    if ( !textField.val() && imageChecker === 0 ) {
+      alert('either text or image is required');
+    } else {
+      var formData = buildFormData( $(this) );
+      $.ajax({
+        type: 'POST',
+        url: './messages.json',
+        data: formData,
+        processData: false,
+        contentType: false
+      })
+      .done(function(data) {
+        $('.messages').append(buildHTML(data));
+        resetInput($('#message_body'));
+        window.scrollTo(0, document.body.scrollHeight);
+        enableSubmitButton();
+      })
+      .fail(function() {
+        alert('error');
+        enableSubmitButton();
+      })
+    };
   });
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -23,6 +23,9 @@ $(function() {
                   '<div class="message__content">' +
                     message.body +
                   '</div>' +
+                  '<div class="message__image">' +
+                    '<img src="' + message.image + '">' +
+                  '</div>' +
                 '</li>');
     return html;
   }

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -26,10 +26,14 @@ $(function() {
                   '<div class="message__content">' +
                     message.body +
                   '</div>' +
-                  '<div class="message__image">' +
-                    '<img src="' + message.image + '">' +
-                  '</div>' +
                 '</li>');
+    if (imageChecker !== 0) {
+      html.append(
+        '<div class="message__image">' +
+          '<img src="' + message.image + '">' +
+        '</div>'
+      );
+    }
     return html;
   }
 
@@ -57,6 +61,7 @@ $(function() {
 
   // 画像は選択されると自動的に送信される
   fileInput.on('change', function() {
+    imageChecker = 1; // 一時的に変数を書き換えてバリデーションを通す
     messageForm.trigger('submit');
     resetInput($(this));
   });
@@ -81,6 +86,7 @@ $(function() {
         resetInput($('#message_body'));
         window.scrollTo(0, document.body.scrollHeight);
         enableSubmitButton();
+        imageChecker = $('input[type=file]')[0].files.length; // 変数を初期化する
       })
       .fail(function() {
         alert('error');

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -43,7 +43,7 @@ $(function() {
     var message = $('.footer__message').val();
     var file = $('input[type=file]')[0].files[0];
     fd.append("body", message);
-    if (imageChecker !== 0) { fd.append("image", file) };
+    fd.append("image", file);
 
     return fd;
   }

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -52,11 +52,6 @@ $(function() {
     return fd;
   }
 
-  // ajax通信時に送信ボタンがフリーズするのを解消する
-  function enableSubmitButton() {
-    $('input[type="submit"]').prop('disabled', false);
-  }
-
   // 引数で渡されたフォームの選択を解除する
   function resetInput(e) {
     e.wrap('<form>').closest('form').get(0).reset();
@@ -89,13 +84,12 @@ $(function() {
         $('.messages').append(buildHTML(data));
         resetInput($('#message_body'));
         window.scrollTo(0, document.body.scrollHeight);
-        enableSubmitButton();
         imageChecker = $('input[type=file]')[0].files.length; // 変数を初期化する
       })
       .fail(function() {
         alert('error communicating');
-        enableSubmitButton();
       })
+      return false;
     };
   });
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,5 +1,6 @@
 $(function() {
   var messageForm = $('#new_message');
+  var fileInput = $('#file-input');
 
   // チャット画面において10秒おきに画面を更新する
   if ($('body').attr('controller') == 'messages') {
@@ -41,9 +42,22 @@ $(function() {
     return fd;
   }
 
+  // ajax通信時に送信ボタンがフリーズするのを解消する
   function enableSubmitButton() {
     $('input[type="submit"]').prop('disabled', false);
   }
+
+  // 画像の選択を解除する
+  function resetInput(e) {
+    e.wrap('<form>').closest('form').get(0).reset();
+    e.unwrap();
+  }
+
+  // 画像は選択されると自動的に送信される
+  fileInput.on('change', function() {
+    messageForm.trigger('submit');
+    resetInput($(this));
+  });
 
   // submit時にjsonで非同期通信を行う
   messageForm.on('submit', function(e) {

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -16,18 +16,20 @@ $(function() {
   // 部分テンプレート_messageの構造に沿う
   function buildHTML(message) {
     var user = $('.sidebar__top-left').html();
-    var html = $('<li class="message">' +
-                  '<div class="message__user">' +
-                    '<span class="message__user-name">' +
-                      user +
-                    '</span>' +
-                    '<span class="message__posted-time"> ' +
-                      message.time +
-                    '</span>' +
-                  '<div class="message__content">' +
-                    message.body +
-                  '</div>' +
-                '</li>');
+    var html = $(
+      '<li class="message">' +
+        '<div class="message__user">' +
+          '<span class="message__user-name">' +
+            user +
+          '</span>' +
+          '<span class="message__posted-time"> ' +
+            message.time +
+          '</span>' +
+        '<div class="message__content">' +
+          message.body +
+        '</div>' +
+      '</li>'
+    );
     // 画像が送信された時にのみ画像表示テンプレートを当てる
     if (imageChecker !== 0) {
       html.append(

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -53,7 +53,7 @@ $(function() {
     $('input[type="submit"]').prop('disabled', false);
   }
 
-  // 画像の選択を解除する
+  // 引数で渡されたフォームの選択を解除する
   function resetInput(e) {
     e.wrap('<form>').closest('form').get(0).reset();
     e.unwrap();

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -41,6 +41,10 @@ $(function() {
     return fd;
   }
 
+  function enableSubmitButton() {
+    $('input[type="submit"]').prop('disabled', false);
+  }
+
   // submit時にjsonで非同期通信を行う
   messageForm.on('submit', function(e) {
     e.preventDefault();
@@ -56,11 +60,11 @@ $(function() {
       $('.messages').append(buildHTML(data));
       $('#message_body').val('');
       window.scrollTo(0, document.body.scrollHeight);
-      $('input[type="submit"]').prop('disabled', false);
+      enableSubmitButton();
     })
     .fail(function() {
       alert('error');
-      $('input[type="submit"]').prop('disabled', false);
+      enableSubmitButton();
     })
   });
 });

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,3 @@
 json.set! :body, @message.body
-json.set! :image, @message.image
+json.set! :image, @message.image.url
 json.set! :time, @message.created_at.strftime('%F %T')


### PR DESCRIPTION
## WHAT
- 非同期通信で画像の送信・表示をできるようにする
- フォームが空の際にhtmlが生成されないようにする
- 画像が送信された時のみ画像用のテンプレートを生成する
- 画像が選択された際に自動的にsubmitイベントが発火するようにする
- 画像送信後はフォームを初期化する

## WHY
- 画像投稿機能はHTMLリクエストでしか使えていないため改善する必要があるから
- formDataを利用するとフォームが空でもテンプレートが生成されてしまうから
- 画像が送信されなくてもjsonが画像の情報（= null）を返してしまうことを防ぐため
- 画像選択後あらためてsendボタンをクリックしに行くのは手間がかかるため
- フォームを初期化しないと次回以降の投稿にも画像が反映されてしまうため