### PR TITLE
Extend front-end functions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'puma', '~> 3.0'                      # Use Puma as the app server
 gem 'sass-rails', '~> 5.0'                # Use SCSS for stylesheets
 gem 'uglifier', '>= 1.3.0'                # Use Uglifier as compressor for JavaScript assets
 gem 'jquery-rails'                        # Use jquery as the JavaScript library
-gem 'turbolinks', '~> 5'                  # Turbolinks makes navigating your web application faster
 gem 'jbuilder', '~> 2.5'                  # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,9 +253,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.2)
@@ -306,7 +303,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -5,11 +5,24 @@ $(function() {
   var textField = $('#message_body');
   var imageChecker = $('input[type=file]')[0].files.length;
 
-  // チャット画面において10秒おきに画面を更新する
+  $(document).on('turbolinks:load', function() {
+    scrollToBottom();
+  })
+
+  // チャット画面の最下部まで移動する関数
+  function scrollToBottom() {
+    var messageBoard = $('.message-board__content');
+    var scrollToTop = { scrollTop: messageBoard.prop("scrollHeight") };
+    setTimeout(function(){
+      messageBoard.animate(scrollToTop, 1000);
+    })
+  }
+
+  // チャット画面において30秒おきに画面を更新する
   if ($('body').attr('controller') == 'messages') {
     setInterval(function() {
       window.location.reload()
-    }, 10000);
+    }, 30000);
   }
 
   // メッセージ毎にhtmlを構築する作業を関数として定義
@@ -83,8 +96,8 @@ $(function() {
       .done(function(data) {
         $('.messages').append(buildHTML(data));
         resetInput($('#message_body'));
-        window.scrollTo(0, document.body.scrollHeight);
         imageChecker = $('input[type=file]')[0].files.length; // 変数を初期化する
+        scrollToBottom();
       })
       .fail(function() {
         alert('error communicating');

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -10,10 +10,11 @@ $(function() {
   // チャット画面の最下部まで移動する関数
   function scrollToBottom() {
     var messageBoard = $('.message-board__content');
-    var scrollToTop = { scrollTop: messageBoard.prop("scrollHeight") };
     setTimeout(function(){
-      messageBoard.animate(scrollToTop, 1000);
-    })
+      messageBoard.animate({
+        scrollTop: messageBoard.prop('scrollHeight')
+      }, 1000);
+    }, 100);
   }
 
   // チャット画面において30秒おきに画面を更新する

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -5,9 +5,7 @@ $(function() {
   var textField = $('#message_body');
   var imageChecker = $('input[type=file]')[0].files.length;
 
-  $(document).on('turbolinks:load', function() {
-    scrollToBottom();
-  })
+  scrollToBottom();
 
   // チャット画面の最下部まで移動する関数
   function scrollToBottom() {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,6 @@
 @import "./reset";
 @import "font-awesome";
 @import "./mixin/clearfix";
-@import "./mixin/position_absolute";
 @import "./chat_groups";
 @import "./user";
 @import "./modules/flash_message";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "./reset";
 @import "font-awesome";
 @import "./mixin/clearfix";
+@import "./mixin/position_absolute";
 @import "./chat_groups";
 @import "./user";
 @import "./modules/flash_message";

--- a/app/assets/stylesheets/chat_groups.scss
+++ b/app/assets/stylesheets/chat_groups.scss
@@ -1,18 +1,20 @@
 @import "./color";
 .contents {
-  height: 900px;
   min-width: 980px;
+
   .sidebar {
     height: 100%;
     width: 300px;
     float: left;
     background-color: $navy;
     position: fixed;
+
     .sidebar__top {
       background-color: $darkNavy;
       height: 60px;
       width: 260px;
       padding: 20px;
+
       .sidebar__top-left {
         font-size: 16px;
         font-weight: bold;
@@ -20,31 +22,41 @@
         color: white;
         line-height: 60px;
       }
+
       .sidebar__top-right {
         float: right;
         line-height: 60px;
+
         a {
           margin-left: 3px;
           font-size: 20px;
+
           i {
             color: white;
           }
         }
       }
     }
+
     .sidebar__column {
       height: calc(100% - 100px);
+      overflow-y: scroll;
+
       ul.groups a {
         text-decoration: none;
+
         li.group {
+          padding: 20px;
+
           &:hover {
             background-color: $lightNavy;
           }
-          padding: 20px;
+
           .group__title {
             color: white;
             font-size: 15px;
           }
+
           .group__content {
             color: white;
             font-size: 11px;
@@ -54,84 +66,99 @@
       }
     }
   }
+
   .message-board {
     width: calc(100% - 300px);
     float: left;
     padding-left: 300px;
+
     .message-board__header {
-      @include clearfix();
+      @include position_absolute();
+      top: 0;
       height: 100px;
-      width: calc(100% - 380px);
       padding: 0 40px;
-      position: fixed;
       background-color: white;
+      border-bottom: solid 1px #eee;
+
       .message-board__header-left {
         float: left;
+
         .header__group-name {
           padding-top: 35px;
           font-size: 20px;
           color: $black;
         }
+
         .header__group-members {
           padding-top: 10px;
           font-size: 12px;
           color: $gray;
         }
       }
+
       .message-board__header-right {
         float: right;
         margin-top: 28px;
-          a {
-            cursor: pointer;
-            text-decoration: none;
-            display: inline-block;
-            line-height: 40px;
-            padding: 0 20px;
-            font-size: 14px;
-            color: $blue;
-            border: solid 2px $blue;
-          }
+
+        a {
+          cursor: pointer;
+          text-decoration: none;
+          display: inline-block;
+          line-height: 40px;
+          padding: 0 20px;
+          font-size: 14px;
+          color: $blue;
+          border: solid 2px $blue;
+        }
       }
     }
+
     .message-board__content {
-      padding: 100px 40px;
+      @include position_absolute();
+      top: 100px;
+      padding: 0 40px;
       background-color: $lightGray;
-      border-top: solid 1px #eee;
-      min-height: 697px;
+      height: calc(100% - 190px);
+      overflow-y: scroll;
+
       ul.messages li.message {
         .message__user {
-          padding-top: 40px;
+          padding-top: 20px;
+
           .message__user-name {
             font-weight: bold;
             font-size: 14px;
             color: $black;
             margin-right: 10px;
           }
+
           .message__posted-time {
             font-size: 12px;
             color: $gray;
           }
         }
+
         .message__content {
           padding-top: 10px;
+          padding-bottom: 20px;
           font-size: 14px;
         }
       }
     }
+
     .message-board__footer {
+      @include position_absolute();
+      bottom: 0;
       padding: 20px 40px;
       background-color: #ddd;
-      @include clearfix();
-      position: fixed;
-      right: 0;
-      bottom: 0;
-      height: 90;
+      height: 50px;
       width: calc(100% - 380px);
+
       #message-form {
         margin: auto;
+
         .footer__message {
           width: calc(100% - 155px);
-          height: 50px;
           padding: 15px 10px;
           line-height: 20px;
           border: none;
@@ -139,7 +166,9 @@
           float: left;
           box-sizing: border-box;
         }
+
         .image-upload {
+
           label {
             width: 40px;
             height: 50px;
@@ -149,10 +178,12 @@
             float: left;
             cursor: pointer;
           }
+
           input {
             display: none;
           }
         }
+
         .send-button {
           height: 50px;
           width: 100px;

--- a/app/assets/stylesheets/chat_groups.scss
+++ b/app/assets/stylesheets/chat_groups.scss
@@ -1,4 +1,5 @@
 @import "./color";
+@import "./mixin/position_absolute";
 .contents {
   min-width: 980px;
 

--- a/app/assets/stylesheets/mixin/_position_absolute.scss
+++ b/app/assets/stylesheets/mixin/_position_absolute.scss
@@ -1,0 +1,5 @@
+@mixin position_absolute() {
+  position: absolute;
+  left: 300px;
+  right: 0
+}

--- a/app/assets/stylesheets/modules/flash_message.scss
+++ b/app/assets/stylesheets/modules/flash_message.scss
@@ -4,11 +4,18 @@
   line-height: 30px;
   color: white;
   text-align: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
+
   p.flash-message__notice {
     background-color: $blue;
     position: fixed;
     width: 100%;
   }
+
   p.flash-message__alert {
     background-color: $red;
     position: fixed;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,8 +5,8 @@
     %title Chatspace
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
   %body{controller: controller_name}
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     - if flash.any?
       .flash-message
         %p.flash-message__notice= notice

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,7 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title Chatspace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body{controller: controller_name}
     - if flash.any?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,8 +5,8 @@
     %title Chatspace
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body{controller: controller_name}
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     - if flash.any?
       .flash-message
         %p.flash-message__notice= notice


### PR DESCRIPTION
## WHAT
- サイドバーをスクロール可能にする
- メッセージボードに `position: absolute;` と `overflow-y: scroll;` を当てる
- `position: absolute;` の導入に伴って、フラッシュメッセージの css を修正する
- グループ選択時に自動でチャット画面の最下部までスクロールさせる
- `javascript_include_tag` を head から body に移動する

## WHY
- グループが多くなっても見切れないようにするため
- サイドバーとメッセージボードでスクロールバーを互いに独立させるため
- 最新のメッセージを見せることができるようにするため
- turbolinks の対象から外すことで、http通信ごとに js が読み込まれるようにするため