### PR TITLE
Modify deployment configuration

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,5 +1,5 @@
-require "capistrano/setup"
-require "capistrano/deploy"
+require 'capistrano/setup'
+require 'capistrano/deploy'
 
 require 'capistrano/rbenv'
 require 'capistrano/bundler'
@@ -10,4 +10,4 @@ require 'capistrano3/unicorn'
 require 'capistrano/scm/git'
 install_plugin Capistrano::SCM::Git
 
-Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Capfile
+++ b/Capfile
@@ -7,4 +7,7 @@ require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano3/unicorn'
 
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
+
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -39,3 +39,7 @@ end
 after_fork do |_server, _worker|
   defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
 end
+
+before_exec do |server|
+  ENV['BUNDLE_GEMFILE'] = "#{app_path}/current/Gemfile"
+end

--- a/lib/tasks/unicorn.rake
+++ b/lib/tasks/unicorn.rake
@@ -17,7 +17,7 @@ namespace :unicorn do
 
   def unicorn_pid
     begin
-      File.read("/tmp/pids/unicorn.pid").to_i
+      File.read("/var/www/rails-capistrano-test/current/tmp/pids/unicorn.pid").to_i
     rescue Errno::ENOENT
       raise "Unicorn doesn't seem to be running"
     end

--- a/lib/tasks/unicorn.rake
+++ b/lib/tasks/unicorn.rake
@@ -9,6 +9,9 @@ namespace :unicorn do
   desc 'Stop unicorn'
   task(:stop) { unicorn_signal :QUIT }
 
+  desc 'Restart unicorn with USR2'
+  task(:restart) { unicorn_signal :USR2 }
+
   # Helpers
   def unicorn_signal(signal)
     Process.kill signal, unicorn_pid

--- a/lib/tasks/unicorn.rake
+++ b/lib/tasks/unicorn.rake
@@ -1,30 +1,29 @@
 namespace :unicorn do
-
   # Tasks
-  desc "Start unicorn"
+  desc 'Start unicorn'
   task(:start) {
-    config = rails_root + "config/unicorn.rb"
+    config = rails_root + 'config/unicorn.rb'
     sh "bundle exec unicorn_rails -c #{config} -E production"
   }
 
-  desc "Stop unicorn"
-  task(:stop) {unicorn_signal :QUIT}
+  desc 'Stop unicorn'
+  task(:stop) { unicorn_signal :QUIT }
 
   # Helpers
-  def unicorn_signal signal
+  def unicorn_signal(signal)
     Process.kill signal, unicorn_pid
   end
 
   def unicorn_pid
     begin
-      File.read("/var/www/rails-capistrano-test/current/tmp/pids/unicorn.pid").to_i
+      File.read('/var/www/rails-capistrano-test/current/tmp/pids/unicorn.pid').to_i
     rescue Errno::ENOENT
       raise "Unicorn doesn't seem to be running"
     end
   end
 
   def rails_root
-    require "pathname"
-    Pathname.new(__FILE__) + "../../.."
+    require 'pathname'
+    Pathname.new(__FILE__) + '../../..'
   end
 end


### PR DESCRIPTION
## WHAT
- 本番環境の設定を見直す
- Unicorn のタスクを修正する

## WHY
- Capistrano でのデプロイ時に Unicorn が再起動できていないことが判明したため
- 以前定義した `rake unicorn:stop` のタスクが rescue されてしまい動作しないため